### PR TITLE
feature/method-inheritance-factor

### DIFF
--- a/src/cpp_ext_stats.py
+++ b/src/cpp_ext_stats.py
@@ -8,6 +8,7 @@ from src.metric_classes.number_of_classes import NumberOfClasses
 from src.metric_classes.class_metric import ClassMetric
 from src.metric_classes.attribute_hiding_factor import AttributeHidingFactor
 from src.metric_classes.method_hiding_factor import MethodHidingFactor
+from src.metric_classes.method_inheritance_factor import MethodInheritanceFactor
 
 
 class CppExtStats:
@@ -22,7 +23,8 @@ class CppExtStats:
         self._metrics = {NumberOfFiles.NAME: number_of_files,
                          NumberOfClasses.NAME: NumberOfClasses(number_of_files.get_files()),
                          AttributeHidingFactor.NAME: AttributeHidingFactor(),
-                         MethodHidingFactor.NAME: MethodHidingFactor()}
+                         MethodHidingFactor.NAME: MethodHidingFactor(),
+                         MethodInheritanceFactor.NAME: MethodInheritanceFactor()}
         self._calculate()
 
     def list(self) -> List[str]:

--- a/src/cursor_classes/class_cursor.py
+++ b/src/cursor_classes/class_cursor.py
@@ -29,7 +29,7 @@ class ClassCursor:
                      visited: tuple[str, str] = None) -> \
             Union[List[AttributeCursor], List[MethodCursor]]:
         """
-        Finds all available attributes in the class.
+        Finds all available cursors of specific type in the class.
 
         :param cursor_kind: Cursor to look for
         :param visited: Set of tuple[filename, class_name] to prevent visiting one class twice
@@ -57,5 +57,6 @@ class ClassCursor:
                     if child.access_specifier != AccessSpecifier.PUBLIC:
                         cur.access_specifier = child.access_specifier
 
+                    cur.inherited = True
                     cursors.append(cur)
         return cursors

--- a/src/cursor_classes/method_cursor.py
+++ b/src/cursor_classes/method_cursor.py
@@ -10,9 +10,10 @@ class MethodCursor:
     def __init__(self, cursor: Cursor):
         self.cursor = cursor
         self.access_specifier = cursor.access_specifier
+        self.inherited = False
 
     def is_hidden(self) -> bool:
         return self.access_specifier in [AccessSpecifier.PRIVATE, AccessSpecifier.PROTECTED]
 
     def is_inherited(self) -> bool:
-        pass
+        return self.inherited

--- a/src/metric_classes/method_inheritance_factor.py
+++ b/src/metric_classes/method_inheritance_factor.py
@@ -1,0 +1,29 @@
+from src.metric_classes.class_metric import ClassMetric
+from src.cursor_classes.class_cursor import ClassCursor
+
+
+class MethodInheritanceFactor(ClassMetric):
+    """ Calculates method inheritance factor """
+
+    NAME = "METHOD_INHERITANCE_FACTOR"
+
+    def __init__(self):
+        self._inherited_methods = 0
+        self._total_methods = 0
+
+    def consume(self, class_cursor: ClassCursor) -> None:
+        """
+        Callback method for processing single reference to a class/struct within the AST.
+        :param class_cursor: Reference to a class/struct within the AST
+        :return: None
+        """
+        for method_cursor in class_cursor.get_methods():
+            self._total_methods += 1
+            if method_cursor.is_inherited():
+                self._inherited_methods += 1
+
+    @property
+    def result(self):
+        if self._total_methods == 0:
+            return 0
+        return self._inherited_methods / self._total_methods

--- a/tests/metric_classes/test_cpp_ext_stats.py
+++ b/tests/metric_classes/test_cpp_ext_stats.py
@@ -5,6 +5,7 @@ from src.metric_classes.number_of_files import NumberOfFiles
 from src.metric_classes.number_of_classes import NumberOfClasses
 from src.metric_classes.method_hiding_factor import MethodHidingFactor
 from src.metric_classes.attribute_hiding_factor import AttributeHidingFactor
+from src.metric_classes.method_inheritance_factor import MethodInheritanceFactor
 
 
 class TestCppExtStats:
@@ -55,5 +56,15 @@ class TestCppExtStats:
     def test_attribute_hiding_factor(self, repo_path, expected):
         stats = CppExtStats(repo_path)
         result = stats.metric(AttributeHidingFactor.NAME)
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "repo_path, expected",
+        list(zip(__repo_paths, [0, 0, 5/8, 1, 1, 1, 15 / 21, 0, 15 / 22]))
+    )
+    def test_method_inheritance_factor(self, repo_path, expected):
+        stats = CppExtStats(repo_path)
+        result = stats.metric(MethodInheritanceFactor.NAME)
 
         assert result == expected


### PR DESCRIPTION
This PR depends on changes in PR #5

1. Method Inheritance Factor is implemented
2. Tests for method_inheritance_factor of CppExtStats are added.

**Virtual and override key words are ignored**, because in C++, it is possible to call both the overridden method and the method that was overridden by using the full method name. You can call them both within the class and outside of the class.

So, in this example, the **Derived class actually has two methods**: the inherited `Base::func()` and its own `Derived::func()`.

```
class Base {
public:
    virtual void func() {}
};

class Derived : public Base {
public:
    void func() override {}
};


int main() {
    Derived d = Derived();
    d.Base::func();
    d.Derived::func();
}
```

According to the definition of Method Inheritance Factor, it is the ratio of the sum of the inherited methods in all classes of the system under consideration to the total number of available methods (locally defined plus inherited) for all classes.
So it equals 1/3 in this example.
