### PR TITLE
refactor/method-metrics

### DIFF
--- a/src/cpp_ext_stats.py
+++ b/src/cpp_ext_stats.py
@@ -5,9 +5,11 @@ from xml.dom import minidom
 from datetime import datetime
 from typing import List
 
+from src.metric_classes.class_metric import ClassMetric
+from src.metric_classes.method_metric import MethodMetric
+
 from src.metric_classes.number_of_files import NumberOfFiles
 from src.metric_classes.number_of_classes import NumberOfClasses
-from src.metric_classes.class_metric import ClassMetric
 from src.metric_classes.attribute_hiding_factor import AttributeHidingFactor
 from src.metric_classes.method_hiding_factor import MethodHidingFactor
 from src.metric_classes.attribute_inheritance_factor import AttributeInheritanceFactor
@@ -75,7 +77,12 @@ class CppExtStats:
 
     def _calculate(self) -> None:
         """Calls callback method of every metric class"""
-        for cls in self._metrics[NumberOfClasses.NAME].get_classes():
-            for metric in self._metrics.values():
+        for metric in self._metrics.values():
+            for cls in self._metrics[NumberOfClasses.NAME].get_classes():
                 if isinstance(metric, ClassMetric):
                     metric.consume(cls)
+
+            if isinstance(metric, MethodMetric):
+                for file in self._metrics[NumberOfFiles.NAME].get_files():
+                    for method in file.get_methods():
+                        metric.consume(method)

--- a/src/cursor_classes/file_cursor.py
+++ b/src/cursor_classes/file_cursor.py
@@ -2,6 +2,7 @@ from typing import List
 from clang.cindex import Cursor, CursorKind
 
 from src.cursor_classes.class_cursor import ClassCursor
+from src.cursor_classes.method_cursor import MethodCursor
 
 
 class FileCursor:
@@ -29,3 +30,22 @@ class FileCursor:
         for child in cursor.get_children():
             class_cursors.extend(self._get_classes(child))
         return class_cursors
+
+    def get_methods(self) -> List[MethodCursor]:
+        """
+        Finds method cursors in the file.
+
+        :return: List[ClassCursor]
+        """
+        return self._get_methods(self.cursor)
+
+    def _get_methods(self, cursor: Cursor) -> List[MethodCursor]:
+        if cursor.location.file and cursor.location.file.name != self.path:
+            return []
+        if cursor.kind == CursorKind.CXX_METHOD:
+            return [MethodCursor(cursor)]
+
+        method_cursors = []
+        for child in cursor.get_children():
+            method_cursors.extend(self._get_methods(child))
+        return method_cursors

--- a/src/cursor_classes/method_cursor.py
+++ b/src/cursor_classes/method_cursor.py
@@ -9,6 +9,7 @@ class MethodCursor:
 
     def __init__(self, cursor: Cursor):
         self.cursor = cursor
+        self.definition = cursor.get_definition()
         self.access_specifier = cursor.access_specifier
         self.inherited = False
 

--- a/src/metric_classes/method_metric.py
+++ b/src/metric_classes/method_metric.py
@@ -1,0 +1,25 @@
+""" Base class for metrics. """
+
+from abc import ABC, abstractmethod
+
+from src.cursor_classes.method_cursor import MethodCursor
+
+
+class MethodMetric(ABC):
+    """ Base class for metrics that are connected with Object-Oriented Design """
+
+    NAME = "METRIC_NAME"
+
+    @property
+    def result(self) -> float:
+        """ Property that returns value of calculated metric. """
+        return 0
+
+    @abstractmethod
+    def consume(self, method_cursor: MethodCursor) -> None:
+        """
+        Callback method for processing single reference to a method within the AST.
+
+        :param method_cursor: Reference to a method within the AST
+        :return: None
+        """

--- a/tests/data/method_calls/several_files/A.cpp
+++ b/tests/data/method_calls/several_files/A.cpp
@@ -1,12 +1,9 @@
-#include "B.cpp"
+#include <string>
+#include "A.h"
 
-class A {
-public:
-    void a1(B b, C c) {
-        b.b1(c);
-        b.b2();
-    }
+int A::a1(B b, C c, const std::string &str) {
+    b.b1(c);
+    return str.length();
+}
 
-    void a2() {}
-};
-
+void A::a2() {}

--- a/tests/data/method_calls/several_files/A.h
+++ b/tests/data/method_calls/several_files/A.h
@@ -1,0 +1,14 @@
+#ifndef A_H
+#define A_H
+
+#include <iostream>
+#include "B.cpp"
+
+class A {
+public:
+    int a1(B, C, const std::string&);
+
+    void a2();
+};
+
+#endif // A_H

--- a/tests/data/method_calls/several_files/B.cpp
+++ b/tests/data/method_calls/several_files/B.cpp
@@ -1,10 +1,7 @@
-#include "C.cpp"
+#include "B.h"
 
-class B {
-public:
-    void b1(C &c) {
-        c.c1();
-    }
+void B::b1(C &c) {
+    c.c1();
+}
 
-    void b2() {}
-};
+void B::b2() {}

--- a/tests/data/method_calls/several_files/B.h
+++ b/tests/data/method_calls/several_files/B.h
@@ -1,0 +1,13 @@
+#ifndef B_H
+#define B_H
+
+#include "C.cpp"
+
+class B {
+public:
+    void b1(C &);
+
+    void b2();
+};
+
+#endif // B_H

--- a/tests/data/method_calls/several_files/C.cpp
+++ b/tests/data/method_calls/several_files/C.cpp
@@ -1,6 +1,5 @@
-class C {
-public:
-    void c1() {}
+#include "C.h"
 
-    void c2() {}
-};
+void C::c1() {}
+
+void C::c2() {}

--- a/tests/data/method_calls/several_files/C.h
+++ b/tests/data/method_calls/several_files/C.h
@@ -1,0 +1,11 @@
+#ifndef C_H
+#define C_H
+
+class C {
+public:
+    void c1();
+
+    void c2();
+};
+
+#endif // C_H


### PR DESCRIPTION
`AverageResponseForAClass` and `AverageNumberOfMessages` are redesigned by changing their base class. So now their `consume` method gets `MethodCursor` instead of `ClassCursor`.